### PR TITLE
Moved VP Point Storage from Player to Lobby

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,6 @@
 plugins {
     java
     id("io.quarkus")
-    id("jacoco")
     id("org.sonarqube") version "6.0.1.5171"
 }
 
@@ -27,6 +26,7 @@ dependencies {
     testImplementation("io.quarkus:quarkus-junit5")
     testImplementation("io.quarkus:quarkus-junit5-mockito")
     testImplementation("io.rest-assured:rest-assured")
+    testImplementation("io.quarkus:quarkus-jacoco")
 }
 
 group = "org.catutd"
@@ -43,6 +43,7 @@ sonar {
         property("sonar.organization", "cataniaunited")
         property("sonar.host.url", "https://sonarcloud.io")
         property("sonar.java.coveragePlugin", "jacoco")
+        property("sonar.coverage.jacoco.xmlReportPaths", "build/jacoco-report/jacoco.xml")
     }
 }
 
@@ -61,14 +62,4 @@ tasks.withType<JavaCompile> {
 
 tasks.test {
     useJUnitPlatform()
-    finalizedBy(tasks.jacocoTestReport)
-}
-
-tasks.jacocoTestReport {
-    dependsOn(tasks.test)
-
-    reports {
-        xml.required.set(true)
-        html.required.set(true)
-    }
 }

--- a/src/main/java/com/example/cataniaunited/cleanup/CleanupService.java
+++ b/src/main/java/com/example/cataniaunited/cleanup/CleanupService.java
@@ -7,6 +7,7 @@ import com.example.cataniaunited.lobby.Lobby;
 import com.example.cataniaunited.lobby.LobbyService;
 import com.example.cataniaunited.player.Player;
 import com.example.cataniaunited.player.PlayerService;
+import io.quarkus.arc.Unremovable;
 import io.quarkus.logging.Log;
 import io.quarkus.scheduler.Scheduled;
 import jakarta.enterprise.context.ApplicationScoped;

--- a/src/main/java/com/example/cataniaunited/cleanup/CleanupService.java
+++ b/src/main/java/com/example/cataniaunited/cleanup/CleanupService.java
@@ -7,7 +7,6 @@ import com.example.cataniaunited.lobby.Lobby;
 import com.example.cataniaunited.lobby.LobbyService;
 import com.example.cataniaunited.player.Player;
 import com.example.cataniaunited.player.PlayerService;
-import io.quarkus.arc.Unremovable;
 import io.quarkus.logging.Log;
 import io.quarkus.scheduler.Scheduled;
 import jakarta.enterprise.context.ApplicationScoped;

--- a/src/main/java/com/example/cataniaunited/game/GameService.java
+++ b/src/main/java/com/example/cataniaunited/game/GameService.java
@@ -95,7 +95,7 @@ public class GameService {
         } else {
             logger.debug("No Port found at settlementPositionId=%s".formatted(settlementPositionId));
         }
-        playerService.addVictoryPoints(playerId, 1);
+        lobbyService.addVictoryPoints(lobbyId, playerId, 1);
     }
 
     /**
@@ -115,7 +115,7 @@ public class GameService {
         }
         GameBoard gameboard = getGameboardByLobbyId(lobbyId);
         gameboard.placeCity(buildRequest);
-        playerService.addVictoryPoints(playerId, 1); // Only add one additional Point
+        lobbyService.addVictoryPoints(lobbyId, playerId, 1); // Only add one additional Point
     }
 
     /**
@@ -145,11 +145,11 @@ public class GameService {
         if (newLength >= MIN_LONGEST_ROAD_LENGTH && newLength > gameboard.getLongestRoadLength()) {
             String oldLongestRoadPlayerId = gameboard.getLongestRoadPlayerId();
             if (oldLongestRoadPlayerId != null && !oldLongestRoadPlayerId.equals(playerId)) {
-                playerService.addVictoryPoints(oldLongestRoadPlayerId, -2);
+                lobbyService.addVictoryPoints(lobbyId, oldLongestRoadPlayerId, -2);
             }
 
             if (!playerId.equals(oldLongestRoadPlayerId)) {
-                playerService.addVictoryPoints(playerId, 2);
+                lobbyService.addVictoryPoints(lobbyId, playerId, 2);
             }
 
             gameboard.setLongestRoad(playerId, newLength);

--- a/src/main/java/com/example/cataniaunited/lobby/Lobby.java
+++ b/src/main/java/com/example/cataniaunited/lobby/Lobby.java
@@ -34,14 +34,15 @@ public class Lobby {
     private final List<String> playerOrder = new CopyOnWriteArrayList<>();
     private final Map<String, PlayerColor> playerColors = new ConcurrentHashMap<>(); // Maps player ID to their assigned color
     private final List<PlayerColor> availableColors = new CopyOnWriteArrayList<>(); // List of colors not yet assigned
+    private final Map<String, Integer> leaderboard = new ConcurrentHashMap<>(); //Map which stores the victory points per player
     private volatile String activePlayer; // ID of the player whose turn it is
     private volatile boolean gameStarted = false; // Flag indicating if the game has started
     private volatile boolean gameEnded = false; // Flag indicating if the game has ended
     private int roundsPlayed = 0;
     private final Map<String, Integer> latestDiceRollOfPlayer = new ConcurrentHashMap<>();
     private final Map<String, Boolean> readyState = new ConcurrentHashMap<>();
-    private Map<String, Integer> cheatCounts = new HashMap<>();
-    private Map<String, Integer> reportCounts = new HashMap<>();
+    private final Map<String, Integer> cheatCounts = new HashMap<>();
+    private final Map<String, Integer> reportCounts = new HashMap<>();
     private final List<ReportRecord> reportRecords = new ArrayList<>();
     private final Set<String> activeCheaters = new HashSet<>();
 
@@ -113,8 +114,9 @@ public class Lobby {
         readyState.remove(player);
         playerOrder.remove(player);
         players.remove(player);
+        resetVictoryPoints(player);
 
-        if(gameStarted && Objects.equals(activePlayer, player)) {
+        if (gameStarted && Objects.equals(activePlayer, player)) {
             nextPlayerTurn();
         }
     }
@@ -324,6 +326,7 @@ public class Lobby {
         this.activePlayer = null;
         this.playerOrder.clear();
         this.readyState.clear();
+        this.leaderboard.clear();
         this.roundsPlayed = 0;
     }
 
@@ -406,5 +409,16 @@ public class Lobby {
         activeCheaters.remove(playerId);
     }
 
+    public void addVictoryPoints(String playerId, int points) {
+        int currentPoints = getVictoryPoints(playerId);
+        this.leaderboard.put(playerId, currentPoints + points);
+    }
 
+    public int getVictoryPoints(String playerId) {
+        return this.leaderboard.getOrDefault(playerId, 0);
+    }
+
+    public void resetVictoryPoints(String playerId) {
+        this.leaderboard.remove(playerId);
+    }
 }

--- a/src/main/java/com/example/cataniaunited/lobby/LobbyService.java
+++ b/src/main/java/com/example/cataniaunited/lobby/LobbyService.java
@@ -130,4 +130,13 @@ public interface LobbyService {
     void toggleReady(String lobbyId, String playerId) throws GameException;
 
     boolean checkForWin(String lobbyId, String playerId) throws GameException;
+
+    /**
+     * Adds a specified number of victory points to a player.
+     *
+     * @param lobbyId  The ID of the lobby.
+     * @param playerId The ID of the player.
+     * @param points   The number of victory points to add.
+     */
+    void addVictoryPoints(String lobbyId, String playerId, int points) throws GameException;
 }

--- a/src/main/java/com/example/cataniaunited/lobby/LobbyServiceImpl.java
+++ b/src/main/java/com/example/cataniaunited/lobby/LobbyServiceImpl.java
@@ -36,6 +36,7 @@ public class LobbyServiceImpl implements LobbyService {
     private static final Logger logger = Logger.getLogger(LobbyServiceImpl.class);
     private final Map<String, Lobby> lobbies = new ConcurrentHashMap<>();
     private static final SecureRandom secureRandom = new SecureRandom();
+    public static final int WIN_THRESHOLD = 10;
 
     @Inject
     PlayerService playerService;
@@ -131,12 +132,12 @@ public class LobbyServiceImpl implements LobbyService {
     @Override
     public void leaveLobby(String lobbyId, String playerId) throws GameException {
         removePlayerFromLobby(lobbyId, playerId);
-        playerService.resetVictoryPoints(playerId);
     }
 
     /**
      * Removes the player with the given ID from all their lobbies.
      * If the player is the host of a lobby, the lobby gets closed and removed
+     *
      * @return A set of lobbies the player was part of
      */
     @Override
@@ -339,11 +340,21 @@ public class LobbyServiceImpl implements LobbyService {
             logger.errorf("Check for win failed -> Player is not in lobby: lobbyId = %s, playerId = %s", lobbyId, playerId);
             throw new GameException("Player %s not part of lobby %s", playerId, lobbyId);
         }
-        if (playerService.checkForWin(playerId)) {
+        if (lobby.getVictoryPoints(playerId) >= WIN_THRESHOLD) {
             lobby.setGameEnded(true);
             return true;
         }
         return false;
+    }
+
+    @Override
+    public void addVictoryPoints(String lobbyId, String playerId, int points) throws GameException {
+        Lobby lobby = getLobbyById(lobbyId);
+        if (!lobby.getPlayers().contains(playerId)) {
+            logger.errorf("Check for win failed -> Player is not in lobby: lobbyId = %s, playerId = %s", lobbyId, playerId);
+            throw new GameException("Player %s not part of lobby %s", playerId, lobbyId);
+        }
+        lobby.addVictoryPoints(playerId, points);
     }
 
     /**

--- a/src/main/java/com/example/cataniaunited/mapper/PlayerMapper.java
+++ b/src/main/java/com/example/cataniaunited/mapper/PlayerMapper.java
@@ -15,6 +15,7 @@ import java.util.Objects;
 public interface PlayerMapper {
 
     @Mapping(source = "player.uniqueId", target = "id")
+    @Mapping(target = "victoryPoints", expression = "java( mapVictoryPoints(player, lobby) )")
     @Mapping(target = "color", expression = "java( mapPlayerColor(player, lobby) )")
     @Mapping(target = "isHost", expression = "java( isHost(player, lobby) )")
     @Mapping(target = "isReady", expression = "java( isReady(player, lobby) )")
@@ -45,5 +46,9 @@ public interface PlayerMapper {
 
     default boolean canRollDice(Player player, @Context Lobby lobby) {
         return lobby.canRollDice(player.getUniqueId());
+    }
+
+    default int mapVictoryPoints(Player player, @Context Lobby lobby) {
+        return lobby.getVictoryPoints(player.getUniqueId());
     }
 }

--- a/src/main/java/com/example/cataniaunited/player/Player.java
+++ b/src/main/java/com/example/cataniaunited/player/Player.java
@@ -24,7 +24,6 @@ public class Player {
     private String username;
     private final String uniqueId;
     private final WebSocketConnection connection;
-    private int victoryPoints = 0;
     HashMap<TileType, Integer> resources = new HashMap<>();
 
     final Set<Port> accessiblePorts = new HashSet<>();
@@ -90,14 +89,6 @@ public class Player {
         return uniqueId;
     }
 
-    public int getVictoryPoints() {
-        return victoryPoints;
-    }
-
-    public void resetVictoryPoints() {
-        this.victoryPoints = 0;
-    }
-
     public void addPort(Port port) {
         if (port == null) {
             throw new IllegalArgumentException("Port can't be null");
@@ -105,16 +96,6 @@ public class Player {
 
         accessiblePorts.add(port);
     }
-
-    /**
-     * Adds a specified number of victory points to the player's total.
-     *
-     * @param victoryPoints The number of victory points to add.
-     */
-    public void addVictoryPoints(int victoryPoints) {
-        this.victoryPoints += victoryPoints;
-    }
-
 
     public WebSocketConnection getConnection() {
         return connection;

--- a/src/main/java/com/example/cataniaunited/player/PlayerService.java
+++ b/src/main/java/com/example/cataniaunited/player/PlayerService.java
@@ -27,7 +27,6 @@ public class PlayerService {
     private final ConcurrentHashMap<String, Player> playersByConnectionId = new ConcurrentHashMap<>();
     private final ConcurrentHashMap<String, Player> playersById = new ConcurrentHashMap<>();
     private final ConcurrentHashMap<String, WebSocketConnection> connectionsByPlayerId = new ConcurrentHashMap<>();
-    public static final int WIN_THRESHOLD = 10;
 
     /**
      * Adds a new player associated with a WebSocket connection.
@@ -103,37 +102,6 @@ public class PlayerService {
     public void clearAllPlayersForTesting() {
         playersByConnectionId.clear();
         playersById.clear();
-    }
-
-    /**
-     * Adds a specified number of victory points to a player.
-     *
-     * @param playerId The ID of the player.
-     * @param points   The number of victory points to add.
-     */
-    public void addVictoryPoints(String playerId, int points) {
-        Player player = getPlayerById(playerId);
-        if (player != null) {
-            player.addVictoryPoints(points);
-        }
-    }
-
-    public void resetVictoryPoints(String playerId) {
-        Player player = getPlayerById(playerId);
-        if (player != null) {
-            player.resetVictoryPoints();
-        }
-    }
-
-    /**
-     * Checks if a player has reached the victory point threshold to win the game.
-     *
-     * @param playerId The ID of the player to check.
-     * @return true if the player has met or exceeded the {@link #WIN_THRESHOLD}, false otherwise or if player not found.
-     */
-    public boolean checkForWin(String playerId) {
-        Player player = getPlayerById(playerId);
-        return player != null && player.getVictoryPoints() >= WIN_THRESHOLD;
     }
 
     public void setUsername(String playerId, String username) throws GameException {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -4,3 +4,4 @@ quarkus.log.level=DEBUG
 qatania.cleanup.threshold-hours = 24
 
 %test.quarkus.log.level=DEBUG
+%test.quarkus.jacoco.report=true

--- a/src/test/java/com/example/cataniaunited/api/GameMessageHandlerTest.java
+++ b/src/test/java/com/example/cataniaunited/api/GameMessageHandlerTest.java
@@ -100,13 +100,13 @@ class GameMessageHandlerTest {
         String player2Username = "Player 2";
         playerService.setUsername(player2.getUniqueId(), player2Username);
 
-        player.addVictoryPoints(6);
-        player2.addVictoryPoints(8);
         player2.receiveResource(TileType.ORE, 3);
         player2.receiveResource(TileType.WOOD, 4);
         String lobbyId = lobbyService.createLobby(player.getUniqueId());
         lobbyService.joinLobbyByCode(lobbyId, player2.getUniqueId());
         Lobby lobby = lobbyService.getLobbyById(lobbyId);
+        lobby.addVictoryPoints(player.getUniqueId(), 6);
+        lobby.addVictoryPoints(player2.getUniqueId(), 8);
         PlayerColor playerColor = lobby.getPlayerColor(player.getUniqueId());
         PlayerColor player2Color = lobby.getPlayerColor(player2.getUniqueId());
 

--- a/src/test/java/com/example/cataniaunited/api/GameWebSocketTest.java
+++ b/src/test/java/com/example/cataniaunited/api/GameWebSocketTest.java
@@ -630,7 +630,7 @@ class GameWebSocketTest {
         lobbyService.getLobbyById(lobbyId).setActivePlayer(player1Id);
 
         doReturn(playerMock).when(playerService).getPlayerById(player1Id);
-        doReturn(true).when(playerService).checkForWin(player1Id);
+        doReturn(true).when(lobbyService).checkForWin(lobbyId, player1Id);
 
         ObjectNode msgNode = JsonNodeFactory.instance.objectNode().put("settlementPositionId", settlementId);
         MessageDTO msg = new MessageDTO(MessageType.PLACE_SETTLEMENT, player1Id, lobbyId, msgNode);
@@ -891,7 +891,7 @@ class GameWebSocketTest {
         assertEquals(mockPlayer2, actualRoad.getOwner());
 
         verify(gameService).placeRoad(lobbyId, player2, roadId);
-        verify(playerService, times(3)).getPlayerById(player2);
+        verify(playerService, times(2)).getPlayerById(player2);
         verify(gameMessageHandler).getGameBoardInformation(lobbyId);
         verify(gameService, times(2)).getGameboardByLobbyId(lobbyId);
     }
@@ -908,7 +908,7 @@ class GameWebSocketTest {
         when(mockPlayer2.getResourceCount(any(TileType.class))).thenReturn(10);
         doReturn(mockPlayer2).when(playerService).getPlayerById(player2);
 
-        doReturn(true).when(playerService).checkForWin(player2);
+        doReturn(true).when(lobbyService).checkForWin(anyString(), eq(player2));
 
         String lobbyId = lobbyService.createLobby(player1);
         lobbyService.joinLobbyByCode(lobbyId, player2);
@@ -981,7 +981,7 @@ class GameWebSocketTest {
 
         verify(gameService).placeRoad(lobbyId, player2, roadId);
         verify(playerService, times(3)).getPlayerById(player2);
-        verify(playerService).checkForWin(player2);
+        verify(lobbyService).checkForWin(lobbyId, player2);
         verify(gameMessageHandler, never()).getGameBoardInformation(lobbyId);
         verify(gameService, times(2)).getGameboardByLobbyId(lobbyId);
     }
@@ -1171,7 +1171,7 @@ class GameWebSocketTest {
         when(mockGameBoard.getJson()).thenReturn(boardStateJson);
         doReturn(mockGameBoard).when(gameService).getGameboardByLobbyId(actualLobbyId);
         doNothing().when(gameService).placeSettlement(actualLobbyId, playerId, settlementPositionId);
-        when(playerService.checkForWin(playerId)).thenReturn(false);
+        when(lobbyService.checkForWin(lobby.getLobbyId(), playerId)).thenReturn(false);
 
         List<String> receivedMessages = new CopyOnWriteArrayList<>();
         CountDownLatch responseLatch = new CountDownLatch(2);
@@ -1218,7 +1218,7 @@ class GameWebSocketTest {
         }
 
         verify(gameService).placeSettlement(actualLobbyId, playerId, settlementPositionId);
-        verify(playerService, atLeastOnce()).checkForWin(playerId);
+        verify(lobbyService, atLeastOnce()).checkForWin(actualLobbyId, playerId);
         verify(gameService, times(1)).getGameboardByLobbyId(actualLobbyId);
     }
 
@@ -1503,19 +1503,19 @@ class GameWebSocketTest {
         lobby.setActivePlayer(winnerPlayerId);
 
         doNothing().when(gameService).placeSettlement(actualLobbyId, winnerPlayerId, settlementPositionId);
-        when(playerService.checkForWin(winnerPlayerId)).thenReturn(true);
+        when(lobbyService.checkForWin(actualLobbyId, winnerPlayerId)).thenReturn(true);
 
         Player mockPlayer = mock(Player.class);
         when(mockPlayer.getUsername()).thenReturn(winnerPlayerId);
         when(mockPlayer.getUniqueId()).thenReturn(winnerPlayerId);
-        when(mockPlayer.getVictoryPoints()).thenReturn(10);
         when(playerService.getPlayerById(winnerPlayerId)).thenReturn(mockPlayer); // <-- Ensure this is how it's resolved
+        lobby.addVictoryPoints(winnerPlayerId, 10);
 
         Player mockPlayer2 = mock(Player.class);
         when(mockPlayer2.getUsername()).thenReturn(loserPlayerId);
         when(mockPlayer2.getUniqueId()).thenReturn(loserPlayerId);
-        when(mockPlayer2.getVictoryPoints()).thenReturn(8);
         when(playerService.getPlayerById(loserPlayerId)).thenReturn(mockPlayer2);
+        lobby.addVictoryPoints(loserPlayerId, 8);
 
         lobbyService.joinLobbyByCode(lobby.getLobbyId(), loserPlayerId);
 
@@ -1567,7 +1567,7 @@ class GameWebSocketTest {
         }
 
         verify(gameService).placeSettlement(actualLobbyId, winnerPlayerId, settlementPositionId);
-        verify(playerService, atLeastOnce()).checkForWin(winnerPlayerId);
+        verify(lobbyService, atLeastOnce()).checkForWin(actualLobbyId, winnerPlayerId);
         verify(gameMessageHandler, times(1)).broadcastWin(actualLobbyId, winnerPlayerId);
         verify(gameService, never()).getGameboardByLobbyId(anyString());
     }
@@ -1613,7 +1613,7 @@ class GameWebSocketTest {
         assertTrue(responseDto.getMessageNode("error").asText().startsWith("Invalid settlement position id: id = "));
 
         verify(gameService, never()).placeSettlement(anyString(), anyString(), anyInt());
-        verify(playerService, never()).checkForWin(anyString());
+        verify(lobbyService, never()).checkForWin(anyString(), anyString());
         verify(gameService, never()).getGameboardByLobbyId(anyString());
     }
 
@@ -1663,7 +1663,7 @@ class GameWebSocketTest {
         assertEquals(gameServiceErrorMessage, responseDto.getMessageNode("error").asText());
 
         verify(gameService).placeSettlement(actualLobbyId, playerId, settlementPositionId);
-        verify(playerService, never()).checkForWin(anyString());
+        verify(lobbyService, never()).checkForWin(anyString(), anyString());
         verify(gameService, never()).getGameboardByLobbyId(anyString());
         verify(gameMessageHandler, never()).broadcastWin(anyString(), anyString());
     }
@@ -2126,10 +2126,9 @@ class GameWebSocketTest {
 
         Player player2 = playerService.getPlayerById(player2ActualId);
         assertNotNull(player2);
-        assertEquals(0, player2.getVictoryPoints());
+        assertEquals(0, lobby.getVictoryPoints(player2ActualId));
 
         verify(lobbyService).leaveLobby(actualLobbyId, player2ActualId);
-        verify(playerService).resetVictoryPoints(player2ActualId);
     }
 
     @Test

--- a/src/test/java/com/example/cataniaunited/cleanup/CleanupServiceTest.java
+++ b/src/test/java/com/example/cataniaunited/cleanup/CleanupServiceTest.java
@@ -25,8 +25,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
@@ -139,6 +141,37 @@ public class CleanupServiceTest {
         assertEquals(2, lobbyService.getLobbyById(lobbyId).getPlayers().size());
 
         verify(lobbyService, never()).removeLobby(anyString());
+    }
+
+    @Test
+    void lobbyCleanupShouldNotFailIfOnePlayerCannotBeRemovedFromLobby() throws GameException {
+        Player player = new Player("Player1");
+        Player player2 = new Player("Player2");
+        String lobbyId = "lob001";
+        Lobby lobby = spy(new Lobby(lobbyId, player.getUniqueId()));
+        doReturn(Instant.now().minus(cleanupThresholdHours + 1, ChronoUnit.HOURS)).when(lobby).getCreatedAt();
+        doReturn(List.of(lobby)).when(lobbyService).getOpenLobbies();
+        doReturn(lobby).when(lobbyService).getLobbyById(lobbyId);
+        lobbyService.joinLobbyByCode(lobbyId, player2.getUniqueId());
+        gameService.createGameboard(lobbyId);
+
+        assertNotNull(gameService.getGameboardByLobbyId(lobbyId));
+        assertEquals(2, lobby.getPlayers().size());
+
+        doThrow(new GameException("Test Exception")).when(lobbyService).removePlayerFromLobby(lobbyId, player.getUniqueId());
+
+        cleanupService.cleanupOldLobbies();
+
+        assertThrows(GameException.class, () -> gameService.getGameboardByLobbyId(lobbyId));
+        assertEquals(1, lobby.getPlayers().size());
+
+        verify(lobbyService).getOpenLobbies();
+        verify(lobbyService).removePlayerFromLobby(lobbyId, player.getUniqueId());
+        verify(lobbyService).removePlayerFromLobby(lobbyId, player2.getUniqueId());
+        verify(gameService).removeGameBoardForLobby(lobbyId);
+        verify(lobbyService).removeLobby(lobbyId);
+        verify(tradingService).removeAllOpenTradeRequestForLobbyId(lobbyId);
+
     }
 
     @Test

--- a/src/test/java/com/example/cataniaunited/game/GameServiceTest.java
+++ b/src/test/java/com/example/cataniaunited/game/GameServiceTest.java
@@ -143,8 +143,9 @@ class GameServiceTest {
         doReturn(PlayerColor.RED).when(lobbyService).getPlayerColor(anyString(), anyString());
         doReturn(2).when(lobbyService).getRoundsPlayed(anyString());
         doNothing().when(lobbyService).checkPlayerTurn(anyString(), anyString());
+        doNothing().when(lobbyService).addVictoryPoints(anyString(), anyString(), anyInt());
         gameService.placeRoad(lobbyId, playerId, 1);
-        verify(playerService, times(1)).addVictoryPoints(playerId, 2);
+        verify(lobbyService, times(1)).addVictoryPoints(lobbyId, playerId, 2);
         verify(gameboardMock, times(1)).setLongestRoad(playerId, 5);
     }
 
@@ -159,6 +160,7 @@ class GameServiceTest {
         doReturn(PlayerColor.RED).when(lobbyService).getPlayerColor(anyString(), anyString());
         doReturn(2).when(lobbyService).getRoundsPlayed(anyString());
         doNothing().when(lobbyService).checkPlayerTurn(anyString(), anyString());
+        doNothing().when(lobbyService).addVictoryPoints(anyString(), anyString(), anyInt());
         List<Road> realRoads = new ArrayList<>();
         List<BuildingSite> sites = new ArrayList<>();
         for (int i = 0; i < 6; i++) sites.add(new BuildingSite(i));
@@ -173,7 +175,7 @@ class GameServiceTest {
         when(gameboardMock.getRoadList()).thenReturn(realRoads);
         when(gameboardMock.getLongestRoadLength()).thenReturn(0);
         gameService.placeRoad(lobbyId, playerId, 1);
-        verify(playerService).addVictoryPoints(playerId, 2);
+        verify(lobbyService).addVictoryPoints(lobbyId, playerId, 2);
         verify(gameboardMock).setLongestRoad(playerId, 5);
     }
 
@@ -344,6 +346,7 @@ class GameServiceTest {
         Player player = mock(Player.class);
         int settlementPositionId = 15;
         String lobbyId = lobbyMock.getLobbyId();
+        doReturn(Set.of(playerId)).when(lobbyMock).getPlayers();
         doReturn(lobbyMock).when(lobbyService).getLobbyById(lobbyId);
         doReturn(true).when(lobbyMock).isPlayerTurn(playerId);
         doReturn(PlayerColor.BLUE).when(lobbyMock).getPlayerColor(playerId);
@@ -360,6 +363,7 @@ class GameServiceTest {
         int settlementPositionId = 5;
         String lobbyId = lobbyMock.getLobbyId();
 
+        doReturn(Set.of(playerId)).when(lobbyMock).getPlayers();
         doReturn(lobbyMock).when(lobbyService).getLobbyById(lobbyId);
         doReturn(true).when(lobbyMock).isPlayerTurn(playerId);
         doReturn(PlayerColor.BLUE).when(lobbyMock).getPlayerColor(playerId);
@@ -370,7 +374,7 @@ class GameServiceTest {
         gameService.placeSettlement(lobbyId, playerId, settlementPositionId);
 
         verify(gameboardMock).placeSettlement(any(BuildRequest.class));
-        verify(playerService).addVictoryPoints(playerId, 1);
+        verify(lobbyService).addVictoryPoints(lobbyId, playerId, 1);
     }
 
     @Test
@@ -394,6 +398,7 @@ class GameServiceTest {
         int settlementPositionId = 1;
         Player player = new Player("player1");
         String lobbyId = lobbyMock.getLobbyId();
+        doReturn(Set.of(player.getUniqueId())).when(lobbyMock).getPlayers();
         doReturn(lobbyMock).when(lobbyService).getLobbyById(lobbyId);
         doReturn(true).when(lobbyMock).isPlayerTurn(player.getUniqueId());
         doReturn(PlayerColor.BLUE).when(lobbyMock).getPlayerColor(player.getUniqueId());
@@ -426,6 +431,7 @@ class GameServiceTest {
         int settlementPositionId = 1;
         Player player = new Player("player1");
         String lobbyId = lobbyMock.getLobbyId();
+        doReturn(Set.of(player.getUniqueId())).when(lobbyMock).getPlayers();
         doReturn(lobbyMock).when(lobbyService).getLobbyById(lobbyId);
         doReturn(true).when(lobbyMock).isPlayerTurn(player.getUniqueId());
         doReturn(PlayerColor.BLUE).when(lobbyMock).getPlayerColor(player.getUniqueId());
@@ -456,16 +462,18 @@ class GameServiceTest {
     void placeRoadShouldDecrementVictoryPointsIfPlayerDoesNotHaveLongestRoadAnymore() throws GameException {
         Player player = new Player("player1");
         Player oldLongestRoadPlayer = new Player("oldLongestRoadPlayer");
-        oldLongestRoadPlayer.addVictoryPoints(2);
         String playerId = player.getUniqueId();
         int settlementPositionId = 15;
         int newLongestRoadLength = 7;
-        String lobbyId = lobbyMock.getLobbyId();
         LongestRoadCalculator longestRoadCalculatorMock = mock(LongestRoadCalculator.class);
 
-        doReturn(lobbyMock).when(lobbyService).getLobbyById(lobbyId);
-        doReturn(true).when(lobbyMock).isPlayerTurn(playerId);
-        doReturn(PlayerColor.BLUE).when(lobbyMock).getPlayerColor(playerId);
+        String lobbyId = lobbyService.createLobby(playerId);
+        Lobby lobby = lobbyService.getLobbyById(lobbyId);
+        lobbyService.joinLobbyByCode(lobbyId, playerId);
+        lobbyService.joinLobbyByCode(lobbyId, oldLongestRoadPlayer.getUniqueId());
+        lobby.addVictoryPoints(oldLongestRoadPlayer.getUniqueId(), 2);
+        lobby.setActivePlayer(playerId);
+
         doReturn(gameboardMock).when(gameService).getGameboardByLobbyId(lobbyId);
         doReturn(longestRoadCalculatorMock).when(gameService).getLongestRoadCalculator();
         doReturn(player).when(playerService).getPlayerById(playerId);
@@ -474,17 +482,17 @@ class GameServiceTest {
         doReturn(newLongestRoadLength - 1).when(gameboardMock).getLongestRoadLength();
         doReturn(oldLongestRoadPlayer.getUniqueId()).when(gameboardMock).getLongestRoadPlayerId();
 
-        assertEquals(0, player.getVictoryPoints());
-        assertEquals(2, oldLongestRoadPlayer.getVictoryPoints());
+        assertEquals(0, lobby.getVictoryPoints(playerId));
+        assertEquals(2, lobby.getVictoryPoints(oldLongestRoadPlayer.getUniqueId()));
 
         gameService.placeRoad(lobbyId, playerId, settlementPositionId);
 
-        assertEquals(2, player.getVictoryPoints());
-        assertEquals(0, oldLongestRoadPlayer.getVictoryPoints());
+        assertEquals(2, lobby.getVictoryPoints(playerId));
+        assertEquals(0, lobby.getVictoryPoints(oldLongestRoadPlayer.getUniqueId()));
 
         verify(gameboardMock).setLongestRoad(playerId, newLongestRoadLength);
-        verify(playerService).addVictoryPoints(oldLongestRoadPlayer.getUniqueId(), -2);
-        verify(playerService).addVictoryPoints(playerId, 2);
+        verify(lobbyService).addVictoryPoints(lobbyId, oldLongestRoadPlayer.getUniqueId(), -2);
+        verify(lobbyService).addVictoryPoints(lobbyId, playerId, 2);
     }
 
 
@@ -528,7 +536,7 @@ class GameServiceTest {
 
         when(gameboardMock.getPortOfBuildingSite(settlementPositionId)).thenReturn(mockPort);
         doNothing().when(gameboardMock).placeSettlement(any(BuildRequest.class));
-        doNothing().when(playerService).addVictoryPoints(anyString(), anyInt());
+        doNothing().when(lobbyService).addVictoryPoints(anyString(), anyString(), anyInt());
 
 
         gameService.placeSettlement(lobbyId, playerId, settlementPositionId);
@@ -536,7 +544,7 @@ class GameServiceTest {
         verify(gameboardMock).placeSettlement(any(BuildRequest.class));
         verify(gameboardMock).getPortOfBuildingSite(settlementPositionId);
         verify(mockPlayer).addPort(mockPort);
-        verify(playerService).addVictoryPoints(playerId, 1);
+        verify(lobbyService).addVictoryPoints(lobbyId, playerId, 1);
     }
 
     @Test
@@ -554,14 +562,14 @@ class GameServiceTest {
 
         when(gameboardMock.getPortOfBuildingSite(settlementPositionId)).thenReturn(null);
         doNothing().when(gameboardMock).placeSettlement(any(BuildRequest.class));
-        doNothing().when(playerService).addVictoryPoints(anyString(), anyInt());
+        doNothing().when(lobbyService).addVictoryPoints(anyString(), anyString(), anyInt());
 
         gameService.placeSettlement(lobbyId, playerId, settlementPositionId);
 
         verify(gameboardMock).placeSettlement(any(BuildRequest.class));
         verify(gameboardMock).getPortOfBuildingSite(settlementPositionId);
         verify(mockPlayer, never()).addPort(any(Port.class));
-        verify(playerService).addVictoryPoints(playerId, 1);
+        verify(lobbyService).addVictoryPoints(lobbyId, playerId, 1);
     }
 
     @Test

--- a/src/test/java/com/example/cataniaunited/lobby/LobbyServiceImplTest.java
+++ b/src/test/java/com/example/cataniaunited/lobby/LobbyServiceImplTest.java
@@ -431,4 +431,34 @@ class LobbyServiceImplTest {
         GameException ge = assertThrows(GameException.class, () -> lobbyService.checkForWin(lobbyId, playerId));
         assertEquals("Player %s not part of lobby %s".formatted(playerId, lobbyId), ge.getMessage());
     }
+
+    @Test
+    void addVictoryPointsIncreasesPointsCorrectly() throws GameException {
+        String lobbyId = lobbyService.createLobby("HostPlayer");
+        Lobby lobby = lobbyService.getLobbyById(lobbyId);
+        Player player = new Player("Player1");
+        lobbyService.joinLobbyByCode(lobbyId, player.getUniqueId());
+        lobbyService.addVictoryPoints(lobbyId, player.getUniqueId(), 2);
+        lobbyService.addVictoryPoints(lobbyId, player.getUniqueId(), 3);
+        assertEquals(5, lobby.getVictoryPoints(player.getUniqueId()));
+    }
+
+    @Test
+    void checkForWinReturnsFalseIfLessThanTenPoints() throws GameException {
+        String lobbyId = lobbyService.createLobby("HostPlayer");
+        Lobby lobby = lobbyService.getLobbyById(lobbyId);
+        Player player = new Player("Player1");
+        lobbyService.joinLobbyByCode(lobbyId, player.getUniqueId());
+        lobbyService.addVictoryPoints(lobbyId, player.getUniqueId(), 9);
+        assertFalse(lobbyService.checkForWin(lobbyId, player.getUniqueId()));
+    }
+
+    @Test
+    void checkForWinReturnsTrueIfTenPoints() throws GameException {
+        String lobbyId = lobbyService.createLobby("HostPlayer");
+        Player player = new Player("Player1");
+        lobbyService.joinLobbyByCode(lobbyId, player.getUniqueId());
+        lobbyService.addVictoryPoints(lobbyId, player.getUniqueId(), 10);
+        assertTrue(lobbyService.checkForWin(lobbyId, player.getUniqueId()));
+    }
 }

--- a/src/test/java/com/example/cataniaunited/lobby/LobbyTest.java
+++ b/src/test/java/com/example/cataniaunited/lobby/LobbyTest.java
@@ -2,6 +2,7 @@ package com.example.cataniaunited.lobby;
 
 import com.example.cataniaunited.exception.GameException;
 import com.example.cataniaunited.player.PlayerColor;
+import io.quarkus.test.junit.QuarkusTest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -9,6 +10,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -16,6 +18,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+@QuarkusTest
 class LobbyTest {
 
     Lobby testLobby;
@@ -437,6 +440,21 @@ class LobbyTest {
 
         lobby.markCheaterAsCaught(playerId);
         assertTrue(lobby.isCheaterAlreadyCaught(playerId));
+    }
+
+    @Test
+    void resetVictoryPointsShouldNotFailOnNonExistingPlayer() {
+        assertDoesNotThrow(() -> testLobby.resetVictoryPoints("non-existent-player-id-123"));
+    }
+
+    @Test
+    void resetVictoryPointsShouldSetVictoryPointsOfPlayerToZero() {
+        String playerId = "TestPlayer";
+        int currentVictoryPoints = testLobby.getVictoryPoints(playerId);
+        testLobby.addVictoryPoints(playerId, 5);
+        assertEquals(currentVictoryPoints + 5, testLobby.getVictoryPoints(playerId));
+        testLobby.resetVictoryPoints(playerId);
+        assertEquals(0, testLobby.getVictoryPoints(playerId));
     }
 
 }

--- a/src/test/java/com/example/cataniaunited/mapper/PlayerMapperTest.java
+++ b/src/test/java/com/example/cataniaunited/mapper/PlayerMapperTest.java
@@ -93,6 +93,7 @@ class PlayerMapperTest {
     void testToDto() {
         Lobby lobbyMock = new Lobby("1234", playerMock.getUniqueId());
         lobbyMock.setActivePlayer(playerMock.getUniqueId());
+        lobbyMock.addVictoryPoints(playerMock.getUniqueId(), 7);
         PlayerColor expectedColor = lobbyMock.getPlayerColor(playerMock.getUniqueId());
         playerMock.receiveResource(TileType.WHEAT, 3);
         playerMock.receiveResource(TileType.SHEEP, 1);
@@ -108,6 +109,7 @@ class PlayerMapperTest {
         assertTrue(playerInfo.isActivePlayer());
         assertTrue(playerInfo.canRollDice());
         assertTrue(playerInfo.isSetupRound());
+        assertEquals(7, playerInfo.victoryPoints());
         assertEquals(3, playerInfo.resources().get(TileType.WHEAT));
         assertEquals(1, playerInfo.resources().get(TileType.SHEEP));
         assertEquals(0, playerInfo.resources().get(TileType.ORE));

--- a/src/test/java/com/example/cataniaunited/player/PlayerServiceTest.java
+++ b/src/test/java/com/example/cataniaunited/player/PlayerServiceTest.java
@@ -18,7 +18,6 @@ import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
@@ -175,28 +174,6 @@ class PlayerServiceTest {
     }
 
     @Test
-    void addVictoryPointsIncreasesPointsCorrectly() {
-        Player player = playerService.addPlayer(mockConnection1);
-        playerService.addVictoryPoints(player.getUniqueId(), 2);
-        playerService.addVictoryPoints(player.getUniqueId(), 3);
-        assertEquals(5, player.getVictoryPoints());
-    }
-
-    @Test
-    void checkForWinReturnsFalseIfLessThanTenPoints() {
-        Player player = playerService.addPlayer(mockConnection1);
-        playerService.addVictoryPoints(player.getUniqueId(), 9);
-        assertFalse(playerService.checkForWin(player.getUniqueId()));
-    }
-
-    @Test
-    void checkForWinReturnsTrueIfTenPoints() {
-        Player player = playerService.addPlayer(mockConnection1);
-        playerService.addVictoryPoints(player.getUniqueId(), 10);
-        assertTrue(playerService.checkForWin(player.getUniqueId()));
-    }
-
-    @Test
     void getAllPlayersReturnsListOfAllPlayers() {
         playerService.addPlayer(mockConnection1);
         List<Player> players = playerService.getAllPlayers();
@@ -253,18 +230,6 @@ class PlayerServiceTest {
     }
 
     @Test
-    void addVictoryPointsForNonExistentPlayerDoesNotThrowErrorAndDoesNotChangeState() {
-        String nonExistentPlayerId = "non-existent-player-id-123";
-        int initialPlayerCount = playerService.getAllPlayers().size();
-
-        assertDoesNotThrow(() -> playerService.addVictoryPoints(nonExistentPlayerId, 5),
-                "Adding victory points to a non-existent player should not throw an exception.");
-
-        assertEquals(initialPlayerCount, playerService.getAllPlayers().size(),
-                "Player count should remain unchanged after attempting to add VP to non-existent player.");
-    }
-
-    @Test
     void sendMessageToPlayerShouldNotThrowExceptionIfSendTextFails() {
         WebSocketConnection mockConnection = mock(WebSocketConnection.class);
         RuntimeException simulatedException = new RuntimeException("Simulated network error during send");
@@ -310,23 +275,6 @@ class PlayerServiceTest {
         playerService.sendMessageToPlayer(null, testMessage);
 
         verify(mockConnection, never()).sendText(testMessage);
-    }
-
-    @Test
-    void resetVictoryPointsShouldNotFailOnNonExistingPlayer() {
-        assertDoesNotThrow(() -> playerService.resetVictoryPoints("non-existent-player-id-123"));
-    }
-
-    @Test
-    void resetVictoryPointsShouldSetVictoryPointsOfPlayerToZero() {
-        Player player = playerService.addPlayer(mockConnection1);
-        int currentVictoryPoints = player.getVictoryPoints();
-        player.addVictoryPoints(5);
-        assertEquals(currentVictoryPoints + 5, player.getVictoryPoints());
-
-        playerService.resetVictoryPoints(player.getUniqueId());
-
-        assertEquals(0, player.getVictoryPoints());
     }
 
     @Test

--- a/src/test/java/com/example/cataniaunited/player/PlayerTest.java
+++ b/src/test/java/com/example/cataniaunited/player/PlayerTest.java
@@ -6,6 +6,7 @@ import com.example.cataniaunited.game.board.ports.GeneralPort;
 import com.example.cataniaunited.game.board.ports.Port;
 import com.example.cataniaunited.game.board.ports.SpecificResourcePort;
 import com.example.cataniaunited.game.board.tile_list_builder.TileType;
+import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.websockets.next.WebSocketConnection;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -23,7 +24,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-
+@QuarkusTest
 class PlayerTest {
 
     Player player;
@@ -219,7 +220,7 @@ class PlayerTest {
     }
 
     @Test
-    void getAccessiblePortsReturnsCorrectPortSet(){
+    void getAccessiblePortsReturnsCorrectPortSet() {
         player.addPort(new GeneralPort());
         player.addPort(new SpecificResourcePort(TileType.WOOD));
         player.addPort(new SpecificResourcePort(TileType.WHEAT));
@@ -317,17 +318,6 @@ class PlayerTest {
 
         assertNotEquals(playerA, playerB, "Players with same fields but different unique IDs should not be equal.");
         assertNotEquals(playerB, playerA, "Players with same fields but different unique IDs should not be equal.");
-    }
-
-    @Test
-    void resetVictoryPointsSetsPointsToZero() {
-        int victoryPoints = player.getVictoryPoints();
-        player.addVictoryPoints(7);
-        assertEquals(victoryPoints + 7, player.getVictoryPoints());
-
-        player.resetVictoryPoints();
-
-        assertEquals(0, player.getVictoryPoints());
     }
 }
 


### PR DESCRIPTION
Moved storage of victory points from player object to lobby object, since they should not me taken over to new lobbies/games. This is more logical and it fixes a bug that a losing player takes their victory points with them to a new game.

Adapted tests and added new ones